### PR TITLE
Fix php 7.0 getName usage in parameter reflection

### DIFF
--- a/src/Sut/Adapter/ReflectionSutDependencyAdapter.php
+++ b/src/Sut/Adapter/ReflectionSutDependencyAdapter.php
@@ -57,7 +57,7 @@ class ReflectionSutDependencyAdapter implements SutDependencyInterface
     public function getType()
     {
         if ($this->propertyReflection->hasType()) {
-            return $this->propertyReflection->getType()->getName();
+            return (string) $this->propertyReflection->getType();
         }
 
         return self::UNKNOWN_TYPE;

--- a/tests/UniGen/Sut/Adapter/ReflectionSutDependencyAdapterTest.php
+++ b/tests/UniGen/Sut/Adapter/ReflectionSutDependencyAdapterTest.php
@@ -96,7 +96,7 @@ class ReflectionSutDependencyAdapterTest extends TestCase
         $type = Mockery::mock(\ReflectionType::class);
 
         $type
-            ->shouldReceive('getName')
+            ->shouldReceive('__toString')
             ->andReturn('typeName');
 
         $this->propertyReflection


### PR DESCRIPTION
Fix issue #2 where reflection method getName is not present in php 7.0